### PR TITLE
feat: make init command more suitable for automation

### DIFF
--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -138,8 +138,8 @@ class StencilInit {
 
         return { 
             ...await this.inquirer.prompt(prompts),
-            ...cliAnswers
-        }
+            ...cliAnswers,
+        };
     }
 
     /**

--- a/lib/stencil-init.js
+++ b/lib/stencil-init.js
@@ -38,8 +38,8 @@ class StencilInit {
      */
     async run (dotStencilFilePath, cliOptions = {}) {
         const oldStencilConfig = this.readStencilConfig(dotStencilFilePath);
-        const defaultAnswers = this.getDefaultAnswers(oldStencilConfig, cliOptions);
-        const answers = await this.askQuestions(defaultAnswers);
+        const defaultAnswers = this.getDefaultAnswers(oldStencilConfig);
+        const answers = await this.askQuestions(defaultAnswers, cliOptions);
         const updatedStencilConfig = this.applyAnswers(oldStencilConfig, answers);
         this.saveStencilConfig(updatedStencilConfig, dotStencilFilePath);
 
@@ -70,38 +70,56 @@ class StencilInit {
 
     /**
      * @param {{port: (number), normalStoreUrl: (string), accessToken: (string)}} stencilConfig
-     * @param {{port: (number), url: (string), token: (string)}} cliOptions
      * @returns {{port: (number), normalStoreUrl: (string), accessToken: (string)}}
      */
-    getDefaultAnswers (stencilConfig, cliOptions) {
+    getDefaultAnswers (stencilConfig) {
         return {
-            normalStoreUrl: cliOptions.url || stencilConfig.normalStoreUrl,
-            accessToken: cliOptions.token || stencilConfig.accessToken,
-            port: cliOptions.port || stencilConfig.port || this.serverConfig.get('/server/port'),
+            normalStoreUrl: stencilConfig.normalStoreUrl,
+            accessToken: stencilConfig.accessToken,
+            port: stencilConfig.port || this.serverConfig.get('/server/port'),
         };
     }
 
     /**
      * @param {{port: (number), normalStoreUrl: (string), accessToken: (string)}} defaultAnswers
+     * @param {{port: (number), url: (string), token: (string)}} cliOptions
      * @returns {Promise<object>}
      */
-    async askQuestions (defaultAnswers) {
-        return await this.inquirer.prompt([
-            {
+    async askQuestions (defaultAnswers, cliOptions) {
+        var prompts = [];
+        var cliAnswers = {};
+
+        if(cliOptions.url){
+            cliAnswers.normalStoreUrl = cliOptions.url;
+        }
+        else{
+            prompts.push({
                 type: 'input',
                 name: 'normalStoreUrl',
                 message: 'What is the URL of your store\'s home page?',
                 validate: val => /^https?:\/\//.test(val) || 'You must enter a URL',
                 default: defaultAnswers.normalStoreUrl,
-            },
-            {
+            });
+        }
+
+        if(cliOptions.token){
+            cliAnswers.accessToken = cliOptions.token;
+        }
+        else{
+            prompts.push({
                 type: 'input',
                 name: 'accessToken',
                 message: 'What is your Stencil OAuth Access Token?',
                 default: defaultAnswers.accessToken,
                 filter: val => val.trim(),
-            },
-            {
+            });
+        }
+
+        if(cliOptions.port){
+            cliAnswers.port = cliOptions.port;
+        }
+        else{
+            prompts.push({
                 type: 'input',
                 name: 'port',
                 message: 'What port would you like to run the server on?',
@@ -115,8 +133,13 @@ class StencilInit {
                         return true;
                     }
                 },
-            },
-        ]);
+            });
+        }
+
+        return { 
+            ...await this.inquirer.prompt(prompts),
+            ...cliAnswers
+        }
     }
 
     /**

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -26,24 +26,57 @@ const getStencilConfig = () => ({
     accessToken: "accessToken_from_stencilConfig",
     githubToken: "githubToken_1234567890",
 });
-const getAnswers = () => ({
-    normalStoreUrl: "https://url-from-answers.mybigcommerce.com",
-    port: 3003,
-    accessToken: "accessToken_from_answers",
-});
+
 const getCliOptions = () => ({
     url: "https://url-from-cli-options.mybigcommerce.com",
     port: 3002,
     token: "accessToken_from_CLI_options",
+});
+const getCliAnswers = () => ({
+    normalStoreUrl: "https://url-from-cli-options.mybigcommerce.com",
+    port: 3002,
+    accessToken: "accessToken_from_CLI_options",
+});
+const getPromptAnswers = () => ({
+    normalStoreUrl: "https://url-from-prompt.mybigcommerce.com",
+    port: 3003,
+    accessToken: "accessToken_from_prompt",
 });
 
 afterEach(() => jest.restoreAllMocks());
 
 describe('StencilInit integration tests', () => {
     describe('run',  () => {
-        it('should perform all the actions, save the result and inform the user about the successful finish', async () => {
+        it('using cli prompts, should perform all the actions, save the result and inform the user about the successful finish', async () => {
             const dotStencilFilePath = './test/_mocks/bin/dotStencilFile.json';
-            const answers = getAnswers();
+            const answers = getPromptAnswers();
+            const expectedResult = JSON.stringify({ customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG, ...answers }, null, 2);
+            const fsWriteFileSyncStub = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
+            const inquirerPromptStub = jest.spyOn(inquirer, 'prompt').mockReturnValue(answers);
+            const consoleErrorStub = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+            const consoleLogStub = jest.spyOn(console, 'log').mockImplementation(jest.fn());
+
+            // Test with real entities, just some methods stubbed
+            const instance = new StencilInit({
+                inquirer,
+                jsonLint,
+                fs,
+                serverConfig,
+                logger: console,
+            });
+            await instance.run(dotStencilFilePath);
+
+            expect(fsWriteFileSyncStub).toHaveBeenCalledTimes(1);
+            expect(inquirerPromptStub).toHaveBeenCalledTimes(1);
+            expect(consoleErrorStub).toHaveBeenCalledTimes(0);
+            expect(consoleLogStub).toHaveBeenCalledTimes(1);
+
+            expect(fsWriteFileSyncStub).toHaveBeenCalledWith(dotStencilFilePath, expectedResult);
+            expect(consoleLogStub).toHaveBeenCalledWith('You are now ready to go! To start developing, run $ ' + 'stencil start'.cyan);
+        }),
+        it('using cli options, should perform all the actions, save the result and inform the user about the successful finish', async () => {
+            const dotStencilFilePath = './test/_mocks/bin/dotStencilFile.json';
+            const answers = getCliAnswers();
             const expectedResult = JSON.stringify({ customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG, ...answers }, null, 2);
             const fsWriteFileSyncStub = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
             const inquirerPromptStub = jest.spyOn(inquirer, 'prompt').mockReturnValue(answers);
@@ -87,7 +120,7 @@ describe('StencilInit unit tests', () => {
             error: jest.fn(),
         };
         inquirerStub = {
-            prompt: jest.fn().mockReturnValue(getAnswers()),
+            prompt: jest.fn().mockReturnValue(getPromptAnswers()),
         };
         jsonLintStub = {
             parse: jest.fn().mockReturnValue(getStencilConfig()),
@@ -186,59 +219,45 @@ describe('StencilInit unit tests', () => {
         // eslint-disable-next-line jest/expect-expect
         it('should not mutate the passed objects', async () => {
             const stencilConfig = getStencilConfig();
-            const cliOptions = getCliOptions();
             const instance = getStencilInitInstance();
 
             await assertNoMutations(
-                [stencilConfig, cliOptions],
-                () => instance.getDefaultAnswers(stencilConfig, cliOptions),
+                [stencilConfig],
+                () => instance.getDefaultAnswers(stencilConfig),
             );
         });
 
-        it('should pick values from cliOptions first if present', async () => {
+        it('should pick values from stencilConfig if not empty', async () => {
             const stencilConfig = getStencilConfig();
-            const cliOptions = getCliOptions();
             const instance = getStencilInitInstance();
 
-            const res = instance.getDefaultAnswers(stencilConfig, cliOptions);
-
-            expect(res.normalStoreUrl).toEqual(cliOptions.url);
-            expect(res.accessToken).toEqual(cliOptions.token);
-            expect(res.port).toEqual(cliOptions.port);
-        });
-
-        it('should pick values from stencilConfig if cliOptions are empty', async () => {
-            const stencilConfig = getStencilConfig();
-            const cliOptions = {};
-            const instance = getStencilInitInstance();
-
-            const res = instance.getDefaultAnswers(stencilConfig, cliOptions);
+            const res = instance.getDefaultAnswers(stencilConfig);
 
             expect(res.normalStoreUrl).toEqual(stencilConfig.normalStoreUrl);
             expect(res.accessToken).toEqual(stencilConfig.accessToken);
             expect(res.port).toEqual(stencilConfig.port);
         });
 
-        it('should pick values from serverConfig if stencilConfig and cliOptions are empty', async () => {
-            const cliOptions = _.pick(getCliOptions(), ['url']);
-            const stencilConfig = _.pick(getStencilConfig(), ['accessToken']);
+        it('should pick values from serverConfig if stencilConfig are empty', async () => {
+            const stencilConfig = _.pick(getStencilConfig(), ['accessToken','url']);
             const instance = getStencilInitInstance();
 
-            const res = instance.getDefaultAnswers(stencilConfig, cliOptions);
+            const res = instance.getDefaultAnswers(stencilConfig);
 
             expect(res.port).toEqual(serverConfigPort);
 
-            expect(res.normalStoreUrl).toEqual(cliOptions.url);
+            expect(res.normalStoreUrl).toEqual(stencilConfig.url);
             expect(res.accessToken).toEqual(stencilConfig.accessToken);
         });
     });
 
     describe('askQuestions', () => {
-        it('should call inquirer.prompt with correct arguments', async () => {
-            const defaultAnswers = getAnswers();
+        it('should call inquirer.prompt with correct arguments when cliOptions are empty', async () => {
+            const defaultAnswers = getPromptAnswers();
+            const cliOptions = {}
             const instance = getStencilInitInstance();
 
-            await instance.askQuestions(defaultAnswers);
+            await instance.askQuestions(defaultAnswers, cliOptions);
 
             expect(inquirerStub.prompt).toHaveBeenCalledTimes(1);
             // We compare the serialized results because the objects contain functions which hinders direct comparison
@@ -284,7 +303,7 @@ describe('StencilInit unit tests', () => {
         // eslint-disable-next-line jest/expect-expect
         it('should not mutate the passed objects', async () => {
             const stencilConfig = getStencilConfig();
-            const answers = getAnswers();
+            const answers = getPromptAnswers();
             const instance = getStencilInitInstance();
 
             await assertNoMutations(
@@ -295,7 +314,7 @@ describe('StencilInit unit tests', () => {
 
         it('should correctly merge values from the passed objects', async () => {
             const stencilConfig = getStencilConfig();
-            const answers = getAnswers();
+            const answers = getPromptAnswers();
             const instance = getStencilInitInstance();
 
             const res = instance.applyAnswers(stencilConfig, answers);
@@ -310,7 +329,7 @@ describe('StencilInit unit tests', () => {
 
         it('should add a customLayouts property with default empty values if it\'s absent in stencilConfig', async () => {
             const stencilConfig = _.omit(getStencilConfig(), 'customLayouts');
-            const answers = getAnswers();
+            const answers = getPromptAnswers();
             const instance = getStencilInitInstance();
 
             const res = instance.applyAnswers(stencilConfig, answers);

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -75,7 +75,7 @@ describe('StencilInit integration tests', () => {
                 "normalStoreUrl": cliOptions.url,
                 "port": cliOptions.port,
                 "accessToken": cliOptions.token,
-            }
+            };
             const expectedResult = JSON.stringify({ customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG, ...cliOptionsAsAnswers }, null, 2);
             const fsWriteFileSyncStub = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
             const inquirerPromptStub = jest.spyOn(inquirer, 'prompt').mockReturnValue({});
@@ -253,7 +253,7 @@ describe('StencilInit unit tests', () => {
     describe('askQuestions', () => {
         it('should call inquirer.prompt with correct arguments when cliOptions are empty', async () => {
             const defaultAnswers = getAnswers();
-            const cliOptions = {}
+            const cliOptions = {};
             const instance = getStencilInitInstance();
 
             await instance.askQuestions(defaultAnswers, cliOptions);

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -26,15 +26,15 @@ const getStencilConfig = () => ({
     accessToken: "accessToken_from_stencilConfig",
     githubToken: "githubToken_1234567890",
 });
+const getAnswers = () => ({
+    normalStoreUrl: "https://url-from-answers.mybigcommerce.com",
+    port: 3003,
+    accessToken: "accessToken_from_answers",
+});
 const getCliOptions = () => ({
     url: "https://url-from-cli-options.mybigcommerce.com",
     port: 3002,
     token: "accessToken_from_CLI_options",
-});
-const getAnswers = () => ({
-    normalStoreUrl: "https://url-from-prompt.mybigcommerce.com",
-    port: 3003,
-    accessToken: "accessToken_from_prompt",
 });
 
 afterEach(() => jest.restoreAllMocks());

--- a/lib/stencil-init.spec.js
+++ b/lib/stencil-init.spec.js
@@ -26,18 +26,12 @@ const getStencilConfig = () => ({
     accessToken: "accessToken_from_stencilConfig",
     githubToken: "githubToken_1234567890",
 });
-
 const getCliOptions = () => ({
     url: "https://url-from-cli-options.mybigcommerce.com",
     port: 3002,
     token: "accessToken_from_CLI_options",
 });
-const getCliAnswers = () => ({
-    normalStoreUrl: "https://url-from-cli-options.mybigcommerce.com",
-    port: 3002,
-    accessToken: "accessToken_from_CLI_options",
-});
-const getPromptAnswers = () => ({
+const getAnswers = () => ({
     normalStoreUrl: "https://url-from-prompt.mybigcommerce.com",
     port: 3003,
     accessToken: "accessToken_from_prompt",
@@ -49,7 +43,7 @@ describe('StencilInit integration tests', () => {
     describe('run',  () => {
         it('using cli prompts, should perform all the actions, save the result and inform the user about the successful finish', async () => {
             const dotStencilFilePath = './test/_mocks/bin/dotStencilFile.json';
-            const answers = getPromptAnswers();
+            const answers = getAnswers();
             const expectedResult = JSON.stringify({ customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG, ...answers }, null, 2);
             const fsWriteFileSyncStub = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
             const inquirerPromptStub = jest.spyOn(inquirer, 'prompt').mockReturnValue(answers);
@@ -76,10 +70,15 @@ describe('StencilInit integration tests', () => {
         }),
         it('using cli options, should perform all the actions, save the result and inform the user about the successful finish', async () => {
             const dotStencilFilePath = './test/_mocks/bin/dotStencilFile.json';
-            const answers = getCliAnswers();
-            const expectedResult = JSON.stringify({ customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG, ...answers }, null, 2);
+            const cliOptions = getCliOptions();
+            const cliOptionsAsAnswers = {
+                "normalStoreUrl": cliOptions.url,
+                "port": cliOptions.port,
+                "accessToken": cliOptions.token,
+            }
+            const expectedResult = JSON.stringify({ customLayouts: DEFAULT_CUSTOM_LAYOUTS_CONFIG, ...cliOptionsAsAnswers }, null, 2);
             const fsWriteFileSyncStub = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
-            const inquirerPromptStub = jest.spyOn(inquirer, 'prompt').mockReturnValue(answers);
+            const inquirerPromptStub = jest.spyOn(inquirer, 'prompt').mockReturnValue({});
             const consoleErrorStub = jest.spyOn(console, 'error').mockImplementation(jest.fn());
             const consoleLogStub = jest.spyOn(console, 'log').mockImplementation(jest.fn());
 
@@ -91,7 +90,7 @@ describe('StencilInit integration tests', () => {
                 serverConfig,
                 logger: console,
             });
-            await instance.run(dotStencilFilePath, getCliOptions());
+            await instance.run(dotStencilFilePath, cliOptions);
 
             expect(fsWriteFileSyncStub).toHaveBeenCalledTimes(1);
             expect(inquirerPromptStub).toHaveBeenCalledTimes(1);
@@ -120,7 +119,7 @@ describe('StencilInit unit tests', () => {
             error: jest.fn(),
         };
         inquirerStub = {
-            prompt: jest.fn().mockReturnValue(getPromptAnswers()),
+            prompt: jest.fn().mockReturnValue(getAnswers()),
         };
         jsonLintStub = {
             parse: jest.fn().mockReturnValue(getStencilConfig()),
@@ -253,7 +252,7 @@ describe('StencilInit unit tests', () => {
 
     describe('askQuestions', () => {
         it('should call inquirer.prompt with correct arguments when cliOptions are empty', async () => {
-            const defaultAnswers = getPromptAnswers();
+            const defaultAnswers = getAnswers();
             const cliOptions = {}
             const instance = getStencilInitInstance();
 
@@ -303,7 +302,7 @@ describe('StencilInit unit tests', () => {
         // eslint-disable-next-line jest/expect-expect
         it('should not mutate the passed objects', async () => {
             const stencilConfig = getStencilConfig();
-            const answers = getPromptAnswers();
+            const answers = getAnswers();
             const instance = getStencilInitInstance();
 
             await assertNoMutations(
@@ -314,7 +313,7 @@ describe('StencilInit unit tests', () => {
 
         it('should correctly merge values from the passed objects', async () => {
             const stencilConfig = getStencilConfig();
-            const answers = getPromptAnswers();
+            const answers = getAnswers();
             const instance = getStencilInitInstance();
 
             const res = instance.applyAnswers(stencilConfig, answers);
@@ -329,7 +328,7 @@ describe('StencilInit unit tests', () => {
 
         it('should add a customLayouts property with default empty values if it\'s absent in stencilConfig', async () => {
             const stencilConfig = _.omit(getStencilConfig(), 'customLayouts');
-            const answers = getPromptAnswers();
+            const answers = getAnswers();
             const instance = getStencilInitInstance();
 
             const res = instance.applyAnswers(stencilConfig, answers);


### PR DESCRIPTION
#### What?

To make this cli tool more 'automatable' it's necessary to remove the dependency of user input when using the `init` command. 

Rather than having a flag that bypasses user input, it would seem more appropriate to have the cli not ask for values that are already provided via the cli options.

This pull request removes the cli options from the 'defaultAnswers' and uses them to determine which prompts are necessary or not.

It then merges the prompt answers with the cli answers to return the same object as before.